### PR TITLE
feat : Add Dockerfile to build PYQT docker

### DIFF
--- a/Docker/Dockerfile
+++ b/Docker/Dockerfile
@@ -1,1 +1,14 @@
-FROM ubuntu:latest
+FROM ubuntu:22.04
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+# Add user
+RUN adduser --quiet --disabled-password qtuser && usermod -a -G audio qtuser
+
+# This fix: libGL error: No matching fbConfigs or visuals found
+ENV LIBGL_ALWAYS_INDIRECT=1
+
+# Install Python 3, PyQt5
+RUN apt-get update && apt-get install -y python3-pyqt5
+
+COPY hello.py /tmp/hello.py

--- a/Docker/hello.py
+++ b/Docker/hello.py
@@ -1,0 +1,22 @@
+"""Docker test script"""
+import sys
+from PyQt5.QtWidgets import QApplication, QWidget, QLabel
+
+
+if __name__ == "__main__":
+    app = QApplication(sys.argv)
+
+    # Build the window widget
+    w = QWidget()
+    w.setGeometry(300, 300, 250, 150)  # x, y, w, h
+    w.setWindowTitle("My First Qt App")
+
+    # Add a label with tooltip
+    label = QLabel("Hello World", w)
+    label.setToolTip("This is a <b>QLabel</b> widget with Tooltip")
+    label.resize(label.sizeHint())
+    label.move(80, 50)
+
+    # Show window and run
+    w.show()
+    app.exec_()


### PR DESCRIPTION
To collaborate with a heterogenous environment, We'll use the docker.

 - Add Docker/Dockerfile that could build the PYQT docker image.
 - Add Docker/hello.py to test the PYQT docker image

```sh
# Build the Image
cd Docker
docker build -t <image_name> .
```

```sh
# Ubuntu, Could be It doesn't work
docker run --rm -it \
    -v /tmp/.X11-unix:/tmp/.X11-unix \
    -e DISPLAY=0 \
    -u qtuser \
    <image_name> python3 /tmp/hello.py
# MAC
socat TCP-LISTEN:6000,reuseaddr,fork UNIX-CLIENT:\"$DISPLAY\" &
IP=$(ifconfig en0 | grep inet | awk '$1=="inet" {print $2}')
docker run --rm -it \
    -v /tmp/.X11-unix:/tmp/.X11-unix \
    -e DISPLAY=$IP:0 \
    -u qtuser \
    <image_name> python3 /tmp/hello.py
```