### PR TITLE
feat : Add control gates

### DIFF
--- a/tests/test_gates.py
+++ b/tests/test_gates.py
@@ -50,6 +50,55 @@ class TestQuantumGates(unittest.TestCase):
             dtype=np.complex128)
         self.assertTrue(np.allclose(result.mat, expected.mat))
 
+    def test_y_gate(self):
+        y_gate = qg.Y(2, 0)
+        qubit = qb.Qubit(2, 1)  # |01>
+        result = y_gate * qubit
+        expected = qb.Qubit(2, 0)  # Expected to be -|00> after Y gate
+        # Y gate applies iσy, so the result should be multiplied by i
+        expected.mat = np.array([[-1j], [0], [0], [0]], dtype=np.complex128)
+        self.assertTrue(np.allclose(result.mat, expected.mat))
+
+    def test_y_gate_squared(self):
+        y_gate = qg.Y(1, 0)
+        qubit = qb.Qubit(1, 0)  # |0>
+        result = y_gate * y_gate * qubit
+        # Applying Y gate twice should be equivalent to applying a I.
+        expected = qb.Qubit(1, 0)  # |0>
+        self.assertTrue(np.allclose(result.mat, expected.mat))
+
+    def test_controlled_x_gate(self):
+        cx_gate = qg.X(
+            n=2, target=0,
+            control=1)  # CNOT with control on qubit 0 and target on qubit 1
+        qubit = qb.Qubit(2, 0b10)  # |10>
+        result = cx_gate * qubit
+        expected = qb.Qubit(2, 0b11)  # Should be |11> after CNOT
+        self.assertTrue(np.allclose(result.mat, expected.mat))
+
+    def test_controlled_z_gate(self):
+        cz_gate = qg.Z(
+            n=2, target=0,
+            control=1)  # CZ with control on qubit 0 and target on qubit 1
+        qubit = qb.Qubit(2, 0b11)  # |11>
+        result = cz_gate * qubit
+        # CZ flips the phase of the target qubit if the control qubit is |1>
+        expected = qb.Qubit(2, 0b11)
+        expected.mat = np.array([[0], [0], [0], [-1]], dtype=np.complex128)
+        self.assertTrue(np.allclose(result.mat, expected.mat))
+
+    def test_controlled_h_gate(self):
+        ch_gate = qg.H(
+            n=2, target=0,
+            control=1)  # CH gate with control on qubit 0 and target on qubit 1
+        qubit = qb.Qubit(2, 0b10)  # |10>
+        result = ch_gate * qubit
+        # CH should apply Hadamard on the target qubit if the control qubit is |1>
+        expected = qb.Qubit(2, 0b10)
+        expected.mat = np.array([[0], [0], [1], [1]],
+                                dtype=np.complex128) / math.sqrt(2)
+        self.assertTrue(np.allclose(result.mat, expected.mat))
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_qubit.py
+++ b/tests/test_qubit.py
@@ -23,16 +23,9 @@ class TestQubit(unittest.TestCase):
         """Test tensor product of two qubits for correctness."""
         q1 = qb.Qubit(2, 1)  # |01>
         q2 = qb.Qubit(2, 2)  # |10>
-<<<<<<< Updated upstream
         q3 = q1 * q2
         expected_mat = np.zeros((16, 1), dtype=np.complex128)
         expected_mat[6, 0] = 1
-=======
-        q3 = q1 * q2  # Expected: |0110>
-        expected_mat = np.array([[0], [0], [0], [0], [0], [0], [1], [0], [0],
-                                 [0], [0], [0], [0], [0], [0], [0]],
-                                dtype=np.complex128)
->>>>>>> Stashed changes
         self.assertTrue(np.allclose(q3.mat, expected_mat))
 
         with self.assertRaises(TypeError):
@@ -64,7 +57,6 @@ class TestQubit(unittest.TestCase):
 
 
     def test_mat_property(self):
-<<<<<<< Updated upstream
         """Test qubit's state matrix property getters/setters."""
         q = qb.Qubit(4, 3)
         new_mat = np.zeros((16, 1), dtype=np.complex128)
@@ -72,16 +64,6 @@ class TestQubit(unittest.TestCase):
         q.mat = new_mat
         self.assertTrue(np.allclose(q.mat, new_mat))
         self.assertEqual(len(q), 4)
-=======
-        q = qb.Qubit(4, 3)  # 4 qubits
-        new_mat = np.array([[1], [0], [0], [0], [0], [0], [0], [0], [0], [0],
-                            [0], [0], [0], [0], [0], [0]],
-                           dtype=np.complex128)
-        q.mat = new_mat
-        self.assertTrue(np.allclose(q.mat, new_mat))
-        self.assertEqual(len(q),
-                         4)  # Ensure the number of qubits is a power of 2
->>>>>>> Stashed changes
 
         with self.assertRaises(ValueError):
             q.mat = np.array([[1, 0], [0, 1]], dtype=np.complex128)
@@ -91,12 +73,8 @@ class TestQubit(unittest.TestCase):
         q1 = qb.Qubit(2, 1)  # |01>
         q2 = qb.Qubit(2, 2)  # |10>
         q_sum = q1 + q2
-<<<<<<< Updated upstream
         expected_mat = np.array([[0], [1], [1], [0]],
                                 dtype=np.complex128)
-=======
-        expected_mat = np.array([[0], [1], [1], [0]], dtype=np.complex128)
->>>>>>> Stashed changes
         self.assertTrue(np.allclose(q_sum.mat, expected_mat))
 
         with self.assertRaises(TypeError):
@@ -107,17 +85,12 @@ class TestQubit(unittest.TestCase):
         q1 = qb.Qubit(2, 2)  # |10>
         q2 = qb.Qubit(2, 2)  # |10>
         q_diff = q1 - q2
-<<<<<<< Updated upstream
         expected_mat = np.zeros((4, 1), dtype=np.complex128)
-=======
-        expected_mat = np.array([[0], [0], [0], [0]], dtype=np.complex128)
->>>>>>> Stashed changes
         self.assertTrue(np.allclose(q_diff.mat, expected_mat))
 
         with self.assertRaises(TypeError):
             q1 - 2
 
-<<<<<<< Updated upstream
     def test_Conjugate_function(self):
         """Test the T property for correct conjugate transpose."""
         qubit = qb.Qubit(n=1, v=0)
@@ -127,8 +100,6 @@ class TestQubit(unittest.TestCase):
         self.assertTrue(np.array_equal(conjugate_transpose,
                                        expected_output),
                         "T function does not produce correct result.")
-=======
->>>>>>> Stashed changes
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
 - Add control gates for all the quantum gate operations.
 - Add y gate missing docstrings in the gates.py file
 - Add unit test codes for Y-gate and Controlled-X, Y, Z, H gates.
 - Fix tests/test_qubit.py's unmerged code bases
 ```
 qtuser@c0cf44643ccc:~/Entanglement_visualizer$ python3 setup.py test
running test
test_base_gate (test_gates.TestQuantumGates) ... ok
test_controlled_h_gate (test_gates.TestQuantumGates) ... ok
test_controlled_x_gate (test_gates.TestQuantumGates) ... ok
test_controlled_z_gate (test_gates.TestQuantumGates) ... ok
test_h_gate (test_gates.TestQuantumGates) ... ok
test_multiple_gates (test_gates.TestQuantumGates) ... ok
test_x_gate (test_gates.TestQuantumGates) ... ok
test_y_gate (test_gates.TestQuantumGates) ... ok
test_y_gate_squared (test_gates.TestQuantumGates) ... ok
test_z_gate (test_gates.TestQuantumGates) ... ok
test_Conjugate_function (test_qubit.TestQubit)
Test the T property for correct conjugate transpose. ... ok
test_add (test_qubit.TestQubit)
Test element-wise addition of two qubits. ... ok
test_init (test_qubit.TestQubit)
Test Qubit initialization with default/specific values. ... ok
test_mat_property (test_qubit.TestQubit)
Test qubit's state matrix property getters/setters. ... ok
test_str (test_qubit.TestQubit)
Test string representation of a qubit. ... ok
test_sub (test_qubit.TestQubit)
Test element-wise subtraction of two qubits. ... ok
test_tensor_product (test_qubit.TestQubit)
Test tensor product of two qubits for correctness. ... ok

----------------------------------------------------------------------
Ran 17 tests in 0.019s

OK
```