### PR TITLE
refactor : Change __str__ decimal to binary

### DIFF
--- a/src/qubit/qubit.py
+++ b/src/qubit/qubit.py
@@ -114,7 +114,8 @@ class Qubit:
         ret = ""
         for i in range(2**self._n):
             if self.mat[i, 0]:
-                ret += f"{self.mat[i,0]}|{i}>"
+                binary = str(bin(i))[2:]
+                ret += f"{self.mat[i,0]}|{binary.zfill(self._n)}>"
                 ret += " + "
         return ret[:-3]
 


### PR DESCRIPTION
 - Change __str__ decimal to binary to improve interpretability
```
# Before
(0.7071067811865475+0j)|0> + (0.7071067811865475+0j)|3>

# After
(0.7071067811865475+0j)|00> + (0.7071067811865475+0j)|11>
````