### PR TITLE
fix : Fix Qubit.__str__ test case

### DIFF
--- a/tests/test_qubit.py
+++ b/tests/test_qubit.py
@@ -36,7 +36,7 @@ class TestQubit(unittest.TestCase):
         # This qubit is in state |3>, which corresponds to binary |11>
 
         q = qb.Qubit(2, 3)
-        expected_str = "(1+0j)|3>"
+        expected_str = "(1+0j)|11>"
         actual_str = str(q)
         self.assertEqual(actual_str, expected_str)
 
@@ -45,13 +45,13 @@ class TestQubit(unittest.TestCase):
         q1 = qb.Qubit(2, 1)  # |01>
         q2 = qb.Qubit(2, 2)  # |10>
         q_super = q1 + q2
-        expected_super_str = "(1+0j)|1>(1+0j)|2>"
+        expected_super_str = "(1+0j)|01> + (1+0j)|10>"
         actual_super_str = str(q_super)
         self.assertEqual(actual_super_str, expected_super_str)
 
         # A qubit with all zero amplitudes should return an empty string
         q_zero = qb.Qubit(2)
-        expected_zero_str = "(1+0j)|0>"
+        expected_zero_str = "(1+0j)|00>"
         actual_zero_str = str(q_zero)
         self.assertEqual(actual_zero_str, expected_zero_str)
 


### PR DESCRIPTION
 - Fix the miss reflextion of __str__ function change in Qubit class.
 
 ```
 $ python3 setup.py test
 test_base_gate (test_gates.TestQuantumGates) ... ok
test_controlled_h_gate (test_gates.TestQuantumGates) ... ok
test_controlled_x_gate (test_gates.TestQuantumGates) ... ok
test_controlled_z_gate (test_gates.TestQuantumGates) ... ok
test_h_gate (test_gates.TestQuantumGates) ... ok
test_multiple_gates (test_gates.TestQuantumGates) ... ok
test_x_gate (test_gates.TestQuantumGates) ... ok
test_y_gate (test_gates.TestQuantumGates) ... ok
test_y_gate_squared (test_gates.TestQuantumGates) ... ok
test_z_gate (test_gates.TestQuantumGates) ... ok
test_Conjugate_function (test_qubit.TestQubit)
Test the T property for correct conjugate transpose. ... ok
test_add (test_qubit.TestQubit)
Test element-wise addition of two qubits. ... ok
test_init (test_qubit.TestQubit)
Test Qubit initialization with default/specific values. ... ok
test_mat_property (test_qubit.TestQubit)
Test qubit's state matrix property getters/setters. ... ok
test_str (test_qubit.TestQubit)
Test string representation of a qubit. ... ok
test_sub (test_qubit.TestQubit)
Test element-wise subtraction of two qubits. ... ok
test_tensor_product (test_qubit.TestQubit)
Test tensor product of two qubits for correctness. ... ok

----------------------------------------------------------------------
Ran 17 tests in 0.005s
```