### PR TITLE
fix: qubitmat2int bug fixed

### DIFF
--- a/src/util/utils.py
+++ b/src/util/utils.py
@@ -7,8 +7,7 @@ def qubitmat2int(q_mat):
     """
     qubit_num, _ = q_mat.shape
     v = 0
-    for i in range(1, qubit_num+1): 
-        v += q_mat[-i][0].real * (2**(qubit_num-i))        
-    v = int(v)
-    
+    for i in range(qubit_num):
+        if q_mat[i] == 1:
+            v = i     
     return v


### PR DESCRIPTION
- Originally the code has changed 2 bit vector to decimal value. 
- However, quantum state vector is one-hot codded vector. 
- So I changed the code to simply find the index of the vector with value 1 which is decimal value of the quantum status. 